### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "keywords": ["omnipay", "shopaholic", "lovata", "october", "cms"],
     "require": {
         "php": ">=7.0",
-        "lovata/oc-ordersshopaholic-plugin": "~1.22"
+        "lovata/oc-ordersshopaholic-plugin": "~1.22",
+        "ignited/laravel-omnipay": "2.*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "lovata/oc-omnipayshopaholic-plugin",
+    "type": "october-plugin",
+    "description": "Payment gateways extension for Shopaholic plugin",
+    "license": "GPL-3.0-only",
+    "homepage": "https://github.com/oc-shopaholic/oc-omnipay-shopaholic-plugin",
+    "keywords": ["omnipay", "shopaholic", "lovata", "october", "cms"],
+    "require": {
+        "php": ">=7.0",
+        "lovata/oc-ordersshopaholic-plugin": "~1.22"
+    }
+}


### PR DESCRIPTION
Including composer.json in a plugin project allows developers to install the plugin via composer.
It would be great if it is also registered on Packagist like oc-shopaholic-plugin.
Thanks!