### PR TITLE
Added support for omnipay v3

### DIFF
--- a/classes/helper/PaymentGateway.php
+++ b/classes/helper/PaymentGateway.php
@@ -48,7 +48,16 @@ class PaymentGateway extends AbstractPaymentGateway
             return [];
         }
 
-        $arGatewayList = Omnipay::getFactory()->find();
+        $obOmnipayFactory = Omnipay::getFactory();
+
+        if (method_exists($obOmnipayFactory, 'find')) {
+            $arGatewayList = Omnipay::getFactory()->find();
+        } elseIf (method_exists($obOmnipayFactory, 'all')) {
+            $arGatewayList = Omnipay::getFactory()->all();
+        } else {
+            return [];
+        }
+
         if (empty($arGatewayList) || !is_array($arGatewayList)) {
             return [];
         }


### PR DESCRIPTION
I made a start at supporting omnipay 3 with this pull request. There are no big changes. I've only tested it with the `omnipay/mollie: ^5.2` gateway.

The only issues I've found right now are the following:
- There is no function for checking available gateways. Right now every plugin should register them manually. The function for checking for available gateways can be added to the `Lovata.OmnipayShopaholic` plugin
- The "Gateway currency" should be in `ISO` format
- Payment method plugin should be requiring `omnipay/omnipay`

In your plugin you need to register the gateway manually. For example:
```php
public function boot()
{
    $factory = Omnipay::getFactory();
    $factory->register('Mollie');
}
```